### PR TITLE
BUGFIX: Don't skip a index job if a node can't be processed

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryQueueIndexer/IndexingJob.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryQueueIndexer/IndexingJob.php
@@ -99,7 +99,8 @@ class IndexingJob implements JobInterface {
 			]);
 			$currentNode = $this->nodeFactory->createFromNodeData($nodeData, $context);
 			if (!$currentNode instanceof NodeInterface) {
-				return TRUE;
+				$this->logger->log(sprintf('Node with identifier %s could not be processed', $node['nodeIdentifier']));
+				continue;
 			}
 			$this->nodeIndexer->setIndexNamePostfix($this->indexPostfix);
 			$this->logger->log(sprintf('Process indexing job for %s', $currentNode));

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryQueueIndexer/IndexingJob.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryQueueIndexer/IndexingJob.php
@@ -95,13 +95,18 @@ class IndexingJob implements JobInterface {
 			$nodeData = $this->nodeDataRepository->findByIdentifier($node['nodeIdentifier']);
 			$context = $this->contextFactory->create([
 				'workspaceName' => $this->workspaceName,
+				'invisibleContentShown' => true,
+				'inaccessibleContentShown' => false,
 				'dimensions' => $node['dimensions']
 			]);
 			$currentNode = $this->nodeFactory->createFromNodeData($nodeData, $context);
+
+			// Skip this iteration if the node can not be fetched from the current context
 			if (!$currentNode instanceof NodeInterface) {
 				$this->logger->log(sprintf('Node with identifier %s could not be processed', $node['nodeIdentifier']));
 				continue;
 			}
+
 			$this->nodeIndexer->setIndexNamePostfix($this->indexPostfix);
 			$this->logger->log(sprintf('Process indexing job for %s', $currentNode));
 			$this->nodeIndexer->indexNode($currentNode);


### PR DESCRIPTION
The nodes that are used to create the index jobs are fetched from the database but hidden fields are not respected. The `NodeFactory` will right now return `null` for the configured context if the node is hidden. If that occurs the index job will return true and all other nodes in that job are skipped.

This fix will just skip the node that is hidden and log an information about that.