### PR TITLE
[TASK] Use flowpack vendor instead of typo3 for jobqueue-beanstalkd

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "Neos CMS ElasticSearch indexer based on beanstalkd (job queue)",
   "license": "MIT",
   "require": {
-    "typo3/jobqueue-beanstalkd": "*",
+    "flowpack/jobqueue-beanstalkd": "*",
     "flowpack/elasticsearch-contentrepositoryadaptor": "^2.0.2",
     "typo3/typo3cr-search": "^2.1.1"
   },


### PR DESCRIPTION
Vendor name for jobqueue-beanstalkd has changed from typo3 to flowpack
