### PR TITLE
BUGFIX: Shorter and doctrine valid queue names, and configurable batchSize

### DIFF
--- a/Classes/LoggerTrait.php
+++ b/Classes/LoggerTrait.php
@@ -26,7 +26,7 @@ trait LoggerTrait
      */
     protected function log($message, $severity = LOG_INFO, $additionalData = null, $packageKey = null, $className = null, $methodName = null)
     {
-        $packageKey = $packageKey ?: 'Flowpack.ElasticSearch.ContentRepositoryQueueIndexer';
+        $packageKey = $packageKey ?: 'Flowpack-ES-NeosCR-QueueIndexer';
         $this->_logger->log($message, $severity, $additionalData, $packageKey, $className, $methodName);
     }
 }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -2,18 +2,19 @@ Flowpack:
   ElasticSearch:
     ContentRepositoryQueueIndexer:
       enableLiveAsyncIndexing: true
+      batchSize: 500
 
   JobQueue:
     Common:
       queues:
-        'Flowpack.ElasticSearch.ContentRepositoryQueueIndexer':
+        'Flowpack-ES-NeosCR-QueueIndexer':
           className: 'Flowpack\JobQueue\Beanstalkd\Queue\BeanstalkdQueue'
           executeIsolated: true
           options:
             host: '127.0.0.1'
             port: 11300
 
-        'Flowpack.ElasticSearch.ContentRepositoryQueueIndexer.Live':
+        'Flowpack-ES-NeosCR-QueueIndexer-Live':
           className: 'Flowpack\JobQueue\Beanstalkd\Queue\BeanstalkdQueue'
           executeIsolated: true
           options:

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Check the ```Settings.yaml``` to adapt based on the Queue package, you need to a
       JobQueue:
         Common:
           queues:
-            'Flowpack.ElasticSearch.ContentRepositoryQueueIndexer':
+            'Flowpack-ES-NeosCR-QueueIndexer':
               className: 'Flowpack\JobQueue\Beanstalkd\Queue\BeanstalkdQueue'
 
-            'Flowpack.ElasticSearch.ContentRepositoryQueueIndexer.Live':
+            'Flowpack-ES-NeosCR-QueueIndexer-Live':
               className: 'Flowpack\JobQueue\Beanstalkd\Queue\BeanstalkdQueue'
 
 # Batch Indexing


### PR DESCRIPTION
Breaking Change!

The queue name `Flowpack.ElasticSearch.ContentRepositoryQueueIndexer` with the dots is not valid for the Flowpack.JobQueue.Doctrine backend. And anyways the queue names are too long for MySQL Tables.
Solution: Renamed to `Flowpack-ES-NeosCR-QueueIndexer` and `Flowpack-ES-NeosCR-QueueIndexer-Live`

In the same I made the batchSize configurable.
If you have few Nodes but a lot of dimensions, you have to reduce the size.