### PR TITLE
FEATURE: Make batch size configurable

### DIFF
--- a/Classes/Command/NodeIndexQueueCommandController.php
+++ b/Classes/Command/NodeIndexQueueCommandController.php
@@ -26,6 +26,7 @@ class NodeIndexQueueCommandController extends CommandController
 
     const BATCH_QUEUE_NAME = 'Flowpack.ElasticSearch.ContentRepositoryQueueIndexer';
     const LIVE_QUEUE_NAME = 'Flowpack.ElasticSearch.ContentRepositoryQueueIndexer.Live';
+    const DEFAULT_BATCH_SIZE = 500;
 
     /**
      * @var JobManager
@@ -68,6 +69,12 @@ class NodeIndexQueueCommandController extends CommandController
      * @Flow\Inject
      */
     protected $nodeIndexer;
+
+    /**
+     * @Flow\InjectConfiguration(package="Flowpack.ElasticSearch.ContentRepositoryQueueIndexer")
+     * @var array
+     */
+    protected $settings;
 
     /**
      * Index all nodes by creating a new index and when everything was completed, switch the index alias.
@@ -210,7 +217,7 @@ class NodeIndexQueueCommandController extends CommandController
         $this->outputLine('<info>++</info> Indexing %s workspace', [$workspaceName]);
         $nodeCounter = 0;
         $offset = 0;
-        $batchSize = 500;
+        $batchSize = $this->settings['batchSize'] ?? static::DEFAULT_BATCH_SIZE;
         while (true) {
             $iterator = $this->nodeDataRepository->findAllBySiteAndWorkspace($workspaceName, $offset, $batchSize);
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -2,7 +2,8 @@ Flowpack:
   ElasticSearch:
     ContentRepositoryQueueIndexer:
       enableLiveAsyncIndexing: true
-
+      # Change size of single batch jobs via this setting (fallback default is 500)
+      # batchSize: 50
   JobQueue:
     Common:
       queues:


### PR DESCRIPTION
To control the memory usage of single indexing jobs better the
batch size can now be configured via the:

    Flowpack:
      ElasticSearch:
        ContentRepositoryQueueIndexer:
          batchSize: 50

configuration setting. For backwards compatibility reasons a fallback
of 500 (the old hardcoded default) exists if the setting was not
configured at all.