### PR TITLE
BUGIFX: Beanstalk client configuration path

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -11,12 +11,14 @@ Flowpack:
           className: 'Flowpack\JobQueue\Beanstalkd\Queue\BeanstalkdQueue'
           executeIsolated: true
           options:
-            host: '127.0.0.1'
-            port: 11300
+            client:
+              host: '127.0.0.1'
+              port: 11300
 
         'Flowpack.ElasticSearch.ContentRepositoryQueueIndexer.Live':
           className: 'Flowpack\JobQueue\Beanstalkd\Queue\BeanstalkdQueue'
           executeIsolated: true
           options:
-            host: '127.0.0.1'
-            port: 11300
+            client:
+              host: '127.0.0.1'
+              port: 11300


### PR DESCRIPTION
As I stumbled upon the configuration as the connection information must be under the option namespace client.

```php
class BeanstalkdQueue implements QueueInterface
{
    /**
     * @param string $name
     * @param array $options
     */
    public function __construct($name, array $options = [])
    {
        $this->name = $name;
        if (isset($options['defaultTimeout'])) {
            $this->defaultTimeout = (integer)$options['defaultTimeout'];
        }
        $clientOptions = isset($options['client']) ? $options['client'] : [];
        $host = isset($clientOptions['host']) ? $clientOptions['host'] : '127.0.0.1';
        $port = isset($clientOptions['port']) ? $clientOptions['port'] : PheanstalkInterface::DEFAULT_PORT;

        $this->client = new Pheanstalk($host, $port, $this->defaultTimeout);
    }
```