### PR TITLE
TASK: Add branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
     }
   },
   "extra": {
+    "branch-alias": {
+       "dev-master": "3.0.x-dev"
+    }
     "applied-flow-migrations": [
       "TYPO3.FLOW3-201201261636",
       "TYPO3.Fluid-201205031303",


### PR DESCRIPTION
This change is required because of the futur removal of the 3.0 branch