### PR TITLE
BUGFIX: Remove duplicate use statement

### DIFF
--- a/Classes/Command/NodeIndexQueueCommandController.php
+++ b/Classes/Command/NodeIndexQueueCommandController.php
@@ -11,8 +11,6 @@ use Flowpack\ElasticSearch\Domain\Model\Mapping;
 use Flowpack\JobQueue\Common\Exception;
 use Flowpack\JobQueue\Common\Job\JobManager;
 use Flowpack\JobQueue\Common\Queue\QueueManager;
-use Flowpack\ElasticSearch\Domain\Model\Mapping;
-use Flowpack\JobQueue\Common\Exception as JobQueueException;
 use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;


### PR DESCRIPTION
The duplicate use statement causes an fatal error.