### PR TITLE
TASK: Configure log messages

### DIFF
--- a/Classes/IndexingJob.php
+++ b/Classes/IndexingJob.php
@@ -44,20 +44,18 @@ class IndexingJob extends AbstractIndexingJob
 
                 // Skip this iteration if the node can not be fetched from the current context
                 if (!$currentNode instanceof NodeInterface) {
-                    $this->log(sprintf('action=indexing step=failed node=%s message="Node could not be processed"', $node['identifier']));
+                    $this->log(sprintf('action=indexing step=failed node=%s message="Node could not be processed"', $node['identifier']), \LOG_WARNING);
                     continue;
                 }
 
                 $this->nodeIndexer->setIndexNamePostfix($this->indexPostfix);
-                $this->log(sprintf('action=indexing step=started node=%s', $currentNode->getIdentifier()));
-
                 $this->nodeIndexer->indexNode($currentNode, $this->targetWorkspaceName);
             }
 
             $this->nodeIndexer->flush();
             $duration = microtime(true) - $startTime;
             $rate = $numberOfNodes / $duration;
-            $this->log(sprintf('action=indexing step=finished number_of_nodes=%d duration=%f nodes_per_second=%f', $numberOfNodes, $duration, $rate));
+            $this->log(sprintf('action=indexing step=finished number_of_nodes=%d duration=%f nodes_per_second=%f', $numberOfNodes, $duration, $rate), \LOG_INFO);
         });
 
         return true;


### PR DESCRIPTION
Set the log severity of some messages
Remove the logging of every processed node as this leads
to huge log files and covers potential errors
when indexing a large amount of nodes