### PR TITLE
BUGFIX: Handle PSR-7 ApiException responses

### DIFF
--- a/Classes/UpdateAliasJob.php
+++ b/Classes/UpdateAliasJob.php
@@ -22,6 +22,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Log\Utility\LogEnvironment;
 use Neos\Flow\Utility\Algorithms;
 use Psr\Log\LoggerInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class UpdateAliasJob implements JobInterface
 {
@@ -137,11 +138,43 @@ class UpdateAliasJob implements JobInterface
                 }
             }
         } catch (ApiException $exception) {
-            $response = json_decode($exception->getResponse(), true, 512, JSON_THROW_ON_ERROR);
-            if ($response->error instanceof \stdClass) {
-                $this->logger->error(sprintf('Old indices for alias %s could not be removed. ElasticSearch responded with status %s, saying "%s: %s"', $this->indexPostfix, $response->status, $response->error->type, $response->error->reason), LogEnvironment::fromMethodName(__METHOD__));
+            $responseBody = $exception->getResponse() instanceof ResponseInterface
+                ? $exception->getResponse()->getBody()->__toString()
+                : (string) $exception->getResponse();
+            $response = json_decode($responseBody, true, 512, JSON_THROW_ON_ERROR);
+
+            if (is_array($response)) {
+                $this->logger->error(
+                    sprintf(
+                        'Old indices for alias %s could not be removed. ElasticSearch responded with status %s, saying "%s: %s"',
+                        $this->indexPostfix,
+                        $response['status'],
+                        $response['error']['type'],
+                        $response['error']['reason']
+                    ),
+                    LogEnvironment::fromMethodName(__METHOD__)
+                );
+            } elseif ($response->error instanceof \stdClass) {
+                $this->logger->error(
+                    sprintf(
+                        'Old indices for alias %s could not be removed. ElasticSearch responded with status %s, saying "%s: %s"',
+                        $this->indexPostfix,
+                        $response->status,
+                        $response->error->type,
+                        $response->error->reason
+                    ),
+                    LogEnvironment::fromMethodName(__METHOD__)
+                );
             } else {
-                $this->logger->error(sprintf('Old indices for alias %s could not be removed. ElasticSearch responded with status %s, saying "%s"', $this->indexPostfix, $response->status, $response->error), LogEnvironment::fromMethodName(__METHOD__));
+                $this->logger->error(
+                    sprintf(
+                        'Old indices for alias %s could not be removed. ElasticSearch responded with status %s, saying "%s"',
+                        $this->indexPostfix,
+                        $response->status,
+                        $response->error
+                    ),
+                    LogEnvironment::fromMethodName(__METHOD__)
+                );
             }
         }
     }


### PR DESCRIPTION
- handle PSR-7 ResponseInterface responses
- extract the response body when available (falling back to string cast)
- log errors for both associative array and stdClass